### PR TITLE
ImportError triggered by scikit-image<=0.14.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(exclude=["test"]),
-    install_requires=["SRTM.py", "numpy", "matplotlib", "scikit-image"],
+    install_requires=["SRTM.py", "numpy", "matplotlib", "scikit-image>=0.14.2"],
     include_package_data=True,
 )


### PR DESCRIPTION
Thank you for creating this neat package!!!! :+1: :+1: :+1:

I have a Python 3.7 environment with numpy=1.16.2 and scikit-image=0.14.1.  When I initially tried to import `ridge_map` I experienced an `ImportError` due to a known issue that is present in scikit-image v0.14.1 and earlier (cf. https://github.com/scikit-image/scikit-image/issues/3649).

This issue was recently resolved in scikit-image v0.14.2, so I suggest making that the minimum requirement in your `setup.py`.

The error I encountered was:

```python
>>> from ridge_map.ridge_map import RidgeMap
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-f7e97cd1cd63> in <module>
----> 1 from ridge_map.ridge_map import RidgeMap

~/bin/anaconda/lib/python3.7/site-packages/ridge_map/ridge_map.py in <module>
      5 import matplotlib.pyplot as plt
      6 import numpy as np
----> 7 from skimage.filters import rank
      8 from skimage.morphology import square
      9 from skimage.util import img_as_ubyte

~/bin/anaconda/lib/python3.7/site-packages/skimage/__init__.py in <module>
    165         _raise_build_error(e)
    166     # All skimage root imports go here
--> 167     from .util.dtype import (img_as_float32,
    168                              img_as_float64,
    169                              img_as_float,

~/bin/anaconda/lib/python3.7/site-packages/skimage/util/__init__.py in <module>
      6 from .apply_parallel import apply_parallel
      7 
----> 8 from .arraycrop import crop
      9 from ._regular_grid import regular_grid, regular_seeds
     10 from .unique import unique_rows

~/bin/anaconda/lib/python3.7/site-packages/skimage/util/arraycrop.py in <module>
      6 
      7 import numpy as np
----> 8 from numpy.lib.arraypad import _validate_lengths
      9 
     10 

ImportError: cannot import name '_validate_lengths' from 'numpy.lib.arraypad' (/home/gb/bin/anaconda/lib/python3.7/site-packages/numpy/lib/arraypad.py)
```