### PR TITLE
Add option to change viewpoint

### DIFF
--- a/ridge_map/ridge_map.py
+++ b/ridge_map/ridge_map.py
@@ -99,7 +99,13 @@ class RidgeMap:
         )
 
     def preprocess(
-        self, *, values=None, water_ntile=10, lake_flatness=3, vertical_ratio=40
+        self,
+        *,
+        values=None,
+        water_ntile=10,
+        lake_flatness=3,
+        vertical_ratio=40,
+        viewpoint="south"
     ):
         """Default preprocessing.
 
@@ -122,6 +128,8 @@ class RidgeMap:
         vertical_ratio : float > 0
             How much to exaggerate hills. Kind of arbitrary. 40 is reasonable,
             but try bigger and smaller values!
+        viewpoint : str in ["south", "west", "north", "east"] (default "south")
+            The compass direction from which the map will be visualised.
 
         Returns
         -------
@@ -142,6 +150,11 @@ class RidgeMap:
         values[nan_vals] = np.nan
         values[np.logical_or(is_water, is_lake)] = np.nan
         values = vertical_ratio * values[-1::-1]  # switch north and south
+
+        switch = {"south": 0, "west": 1, "north": 2, "east": 3}
+        rotations = switch[viewpoint]
+        values = np.rot90(m=values, k=rotations)
+
         return values
 
     def plot_map(


### PR DESCRIPTION
Added a parameter to `get_elevation_data()` to choose a different `viewpoint` than from the south. Acceptable values are `"south"`, `"west"`, `"north"`, or `"east"`. (Default is `"south"` which causes no change in output.)

Uses `np.rot90()` to rotate the array according to the direction chosen. Adds ~3µs for south and ~10µs for any other option on an 80x300 array (could add code to do nothing for south but seems cleaner this way).

Note: this is done in `get_elevation_data()` instead of `preprocess()` so that `num_lines` and `elevation_pts` can be swapped for east/west viewpoints.

Example displaying Cape Town from the north:
```
rm = RidgeMap((
    18.2546331099579220,
    -34.3804619929141992,
    18.7257651154526137,
    -33.8786404204741061
))

values = rm.get_elevation_data(viewpoint="north")
values = rm.preprocess(
    values=values,
    lake_flatness=0,
    water_ntile=60,
)

rm.plot_map(
    values=values,
    label='Cape Town',
    label_y=0.8,
    label_x=0.1,
)
```

![image](https://user-images.githubusercontent.com/19817302/57069791-e4903280-6cd5-11e9-8354-7f8124713bf4.png)
