### PR TITLE
Fixed runtime error in FT2Font

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you pass a matplotlib colormap, you can specify `kind="elevation"` to color t
 ```python
 from ridge_map import FontManager
 
-font = FontManager('https://github.com/google/fonts/blob/master/ofl/uncialantiqua/UncialAntiqua-Regular.ttf?raw=True')
+font = FontManager('https://github.com/google/fonts/blob/main/ofl/uncialantiqua/UncialAntiqua-Regular.ttf?raw=true')
 rm = RidgeMap((-156.250305,18.890695,-154.714966,20.275080), font=font.prop)
 
 values = rm.get_elevation_data(num_lines=100)

--- a/ridge_map/ridge_map.py
+++ b/ridge_map/ridge_map.py
@@ -29,7 +29,7 @@ class FontManager:
 
     def __init__(
         self,
-        github_url="https://github.com/google/fonts/blob/master/ofl/cinzel/static/Cinzel-Regular.ttf?raw=true",  # pylint: disable=line-too-long
+        github_url="https://github.com/google/fonts/blob/main/ofl/cinzel/static/Cinzel-Regular.ttf?raw=true",  # pylint: disable=line-too-long
     ):
         """
         Lazily download a font.
@@ -38,7 +38,7 @@ class FontManager:
         ----------
         github_url : str
             Can really be any .ttf file, but probably looks like
-            "https://github.com/google/fonts/blob/master/ofl/cinzel/Cinzel-Regular.ttf?raw=true"
+            "https://github.com/google/fonts/blob/main/ofl/cinzel/static/Cinzel-Regular.ttf?raw=true"
         """
         self.github_url = github_url
         self._prop = None


### PR DESCRIPTION
Google font renamed it's master branch to main which was causing runtime error in FT2Font. Fixed the issue by changing the url.