### PR TITLE
Changing broken font URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install ridge_map
 Or live on the edge and install from github with
 
 ```bash
-!pip install git+https://github.com/colcarroll/ridge_map.git
+pip install git+https://github.com/atseewal/ridge_map.git
 ```
 
 Want to help?

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install ridge_map
 Or live on the edge and install from github with
 
 ```bash
-pip install git+https://github.com/atseewal/ridge_map.git
+pip install git+https://github.com/colcarroll/ridge_map.git
 ```
 
 Want to help?

--- a/ridge_map/ridge_map.py
+++ b/ridge_map/ridge_map.py
@@ -29,7 +29,7 @@ class FontManager:
 
     def __init__(
         self,
-        github_url="https://github.com/NDISCOVER/Cinzel/blob/master/fonts/ttf/Cinzel-Regular.ttf?raw=True",  # pylint: disable=line-too-long
+        github_url="https://github.com/google/fonts/raw/main/ofl/cinzel/Cinzel%5Bwght%5D.ttf",  # pylint: disable=line-too-long
     ):
         """
         Lazily download a font.
@@ -38,7 +38,7 @@ class FontManager:
         ----------
         github_url : str
             Can really be any .ttf file, but probably looks like
-            "https://github.com/google/fonts/blob/5c3d8ef085f3084db38936d0dcd39a567dbc1e01/ofl/cinzel/static/Cinzel-Regular.ttf?raw=True" # pylint: disable=line-too-long
+            "https://github.com/google/fonts/raw/main/ofl/cinzel/Cinzel%5Bwght%5D.ttf" # pylint: disable=line-too-long
         """
         self.github_url = github_url
         self._prop = None


### PR DESCRIPTION
Not sure if you're actively updating this, but the link to the default font is broken. I updated the default font to point to a Google Fonts version on GitHub.